### PR TITLE
Creepers drop MusicDisc mod discs instead of better than modern when mod is present

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
-    id 'fabric-loom' version '1.6.2'
-    id 'babric-loom-extension' version '1.7.4'
+    id 'maven-publish'
+    id 'fabric-loom' version '1.9.2'
+    id 'babric-loom-extension' version '1.9.4'
 }
 
 sourceCompatibility = JavaVersion.VERSION_17
@@ -56,11 +57,14 @@ repositories {
 dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.glasslauncher:biny:${project.yarn_mappings}:v2"
-    modImplementation "babric:fabric-loader:${project.loader_version}"
+    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     implementation "blue.endless:jankson:1.2.3"
 
     modImplementation "net.modificationstation:StationAPI:${project.stapi_version}"
+    modRuntimeOnly ("maven.modrinth:fast-stapi-intro:${project.stapi_fast_intro_version}") {
+        transitive false
+    }
     modImplementation("com.github.paulevsGitch:BHCreative:${project.bhcreative_version}") {
         transitive false
     }

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,11 @@ repositories {
         name = 'Jitpack'
         url = 'https://jitpack.io'
     }
+    // Used for SpawnEggs
+    maven {
+        name = "NyaRepo"
+        url = "https://maven.fildand.cz/releases"
+    }
     exclusiveContent {
         forRepository {
             maven {
@@ -66,6 +71,12 @@ dependencies {
         transitive false
     }
     modImplementation("com.github.paulevsGitch:BHCreative:${project.bhcreative_version}") {
+        transitive false
+    }
+    modImplementation("maven.modrinth:retrocommands:${project.retrocommands_version}") {
+        transitive false
+    }
+    modImplementation("net.danygames2014:spawneggs:${project.spawneggs_version}") {
         transitive false
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,12 @@ org.gradle.daemon=false
 
 minecraft_version=b1.7.3
 yarn_mappings=b1.7.3+2f404bc
-loader_version=0.15.6-babric.1
+loader_version=0.16.10
 
 mod_version=1.2.1
 maven_group=me.meta4245
 archives_base_name=betterthanmodern
 
 stapi_version=2.0.0-alpha.4
+stapi_fast_intro_version=2.0.0
 bhcreative_version=0.4.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,5 @@ archives_base_name=betterthanmodern
 stapi_version=2.0.0-alpha.4
 stapi_fast_intro_version=2.0.0
 bhcreative_version=0.4.8
+retrocommands_version=0.5.5
+spawneggs_version=1.11.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Aug 20 23:59:44 EEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/me/meta4245/betterthanmodern/mixin/BetterThanModernMixinPlugin.java
+++ b/src/main/java/me/meta4245/betterthanmodern/mixin/BetterThanModernMixinPlugin.java
@@ -1,0 +1,56 @@
+package me.meta4245.betterthanmodern.mixin;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public final class BetterThanModernMixinPlugin implements IMixinConfigPlugin {
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (mixinClassName.equals("me.meta4245.betterthanmodern.mixin.CreeperEntityMixin")) {
+            if (FabricLoader.getInstance().isModLoaded("musicdiscs")) {
+                System.out.println("MusicDisc mod detected! Using music discs from MusicDisc mod instead of BetterThanModern.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // Boilerplate
+
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+}

--- a/src/main/resources/betterthanmodern.mixins.json
+++ b/src/main/resources/betterthanmodern.mixins.json
@@ -3,6 +3,7 @@
   "minVersion": "0.8",
   "package": "me.meta4245.betterthanmodern.mixin",
   "compatibilityLevel": "JAVA_17",
+  "plugin": "me.meta4245.betterthanmodern.mixin.BetterThanModernMixinPlugin",
   "mixins": [
     "AxeItemMixin",
     "BoatEntityMixin",


### PR DESCRIPTION
This should simplify things so that players don't get two sets of discs that behave differently.
It also makes it so that your mod doesn't directly depend on the music disc mod, and can be used independent of it.

Let me know what you think :)